### PR TITLE
Add link to main README with installation instruction

### DIFF
--- a/templates/rescript-template-basic/README.md
+++ b/templates/rescript-template-basic/README.md
@@ -1,5 +1,7 @@
 # ReScript Project Template
 
+- [Installation](../../README.md)
+
 The only official ReScript starter template.
 
 ## Installation

--- a/templates/rescript-template-nextjs/README.md
+++ b/templates/rescript-template-nextjs/README.md
@@ -1,6 +1,6 @@
 # ReScript / NextJS Starter
 
-- [Instalattion](../../README.md)
+- [Installation](../../README.md)
 
 This is a NextJS based template with following setup:
 

--- a/templates/rescript-template-nextjs/README.md
+++ b/templates/rescript-template-nextjs/README.md
@@ -1,8 +1,10 @@
 # ReScript / NextJS Starter
 
+- [Instalattion](../../README.md)
+
 This is a NextJS based template with following setup:
 
-- Full Tailwind v2 config & basic css scaffold (+ production setup w/ purge-css & cssnano)
+- Full Tailwind v3 config & basic css scaffold (+ production setup w/ purge-css & cssnano)
 - [ReScript](https://rescript-lang.org) + React
 - Some ReScript Bindings for Next to get you started
 - Preconfigured Dependencies: `@rescript/react`

--- a/templates/rescript-template-vite/README.md
+++ b/templates/rescript-template-vite/README.md
@@ -1,6 +1,6 @@
 # ReScript / Vite Starter Template
 
-- [Instalattion](../../README.md)
+- [Installation](../../README.md)
 
 This is a Vite-based template with following setup:
 

--- a/templates/rescript-template-vite/README.md
+++ b/templates/rescript-template-vite/README.md
@@ -1,5 +1,7 @@
 # ReScript / Vite Starter Template
 
+- [Instalattion](../../README.md)
+
 This is a Vite-based template with following setup:
 
 - [ReScript](https://rescript-lang.org) 11.0 with @rescript/react and JSX 4 automatic mode


### PR DESCRIPTION
For now, since we don't have a flag `--example nextjs`

ReScript website landing page will link the URL to the `README.md` of each template. 

https://github.com/rescript-association/rescript-lang.org/pull/760