### PR TITLE
Add CI + test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}-1
+  # Cancel previous builds for pull requests only.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+            macos-13, # x64
+            macos-14, # ARM
+            ubuntu-latest, # x64
+            buildjet-2vcpu-ubuntu-2204-arm, # ARM
+            # windows-latest, # deactivated for now as there is still a Windows issue
+          ]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: NPM install
+        run: npm ci
+
+      - name: Build
+        run: npx rescript
+
+      - name: Test
+        env:
+          CI: 1
+        shell: bash
+        run: |
+          npm pack
+          npm i -g ./create-rescript-app-*.tgz
+          npx create-rescript-app

--- a/src/CI.res
+++ b/src/CI.res
@@ -1,0 +1,6 @@
+@val @scope("process.env") external ci: string = "CI"
+
+let isRunningInCI = switch ci {
+| "1" | "true" | "TRUE" => true
+| _ => false
+}

--- a/src/CI.resi
+++ b/src/CI.resi
@@ -1,0 +1,1 @@
+let isRunningInCI: bool

--- a/src/Main.res
+++ b/src/Main.res
@@ -35,7 +35,13 @@ https://rescript-lang.org`,
   let rescriptJsonPath = Path.join2(Process.cwd(), "rescript.json")
   let bsconfigJsonPath = Path.join2(Process.cwd(), "bsconfig.json")
 
-  if Fs.existsSync(rescriptJsonPath) || Fs.existsSync(bsconfigJsonPath) {
+  if CI.isRunningInCI {
+    P.note(~title="CI Mode", ~message="Running in CI, will create a test project")
+    await handleError(~outro="Project creation failed.", async () => {
+      await NewProject.createNewProject()
+      P.outro("CI test completed successfully.")
+    })
+  } else if Fs.existsSync(rescriptJsonPath) || Fs.existsSync(bsconfigJsonPath) {
     ExistingRescriptProject.showUpgradeHint()
     P.outro("No changes were made to your project.")
   } else if Fs.existsSync(packageJsonPath) {


### PR DESCRIPTION
This PR adds a CI build + test for all platform other than Windows. We will try to solve remaining Windows issues in a separate PR.

To test create-rescript-app in CI, we need a way to run it without requiring any user input. For now, I have added a special CI mode for that that is activated by setting `CI=1`. In the long run, we should make it possible to pass all required settings (project name, template name, versions) via the command line instead.