### PR TITLE
Add support v12 alpha

### DIFF
--- a/src/ExistingJsProject.res
+++ b/src/ExistingJsProject.res
@@ -20,7 +20,7 @@ let updatePackageJson = async () =>
     }
   )
 
-let updateRescriptJson = async (~projectName, ~sourceDir, ~moduleSystem, ~suffix) =>
+let updateRescriptJson = async (~projectName, ~sourceDir, ~moduleSystem, ~suffix, ~versions) =>
   await JsonUtils.updateJsonFile("rescript.json", json =>
     switch json {
     | Object(config) =>
@@ -33,6 +33,10 @@ let updateRescriptJson = async (~projectName, ~sourceDir, ~moduleSystem, ~suffix
       switch config->Dict.get("package-specs") {
       | Some(Object(sources)) => sources->Dict.set("module", String(moduleSystem))
       | _ => ()
+      }
+
+      if Option.isNone(versions.RescriptVersions.rescriptCoreVersion) {
+        RescriptJsonUtils.removeRescriptCore(config)
       }
     | _ => ()
     }
@@ -98,7 +102,7 @@ let addToExistingProject = async (~projectName) => {
   }
 
   await updatePackageJson()
-  await updateRescriptJson(~projectName, ~sourceDir, ~moduleSystem, ~suffix)
+  await updateRescriptJson(~projectName, ~sourceDir, ~moduleSystem, ~suffix, ~versions)
 
   if !Fs.existsSync(sourceDirPath) {
     await Fs.Promises.mkdir(sourceDirPath)

--- a/src/NewProject.res
+++ b/src/NewProject.res
@@ -84,7 +84,7 @@ let createNewProject = async () => {
     await createProject(
       ~templateName="rescript-template-basic",
       ~projectName="test",
-      ~versions={rescriptVersion: "11.1.1", rescriptCoreVersion: "1.5.0"},
+      ~versions={rescriptVersion: "11.1.1", rescriptCoreVersion: Some("1.5.0")},
     )
   } else {
     let projectName = await P.text({

--- a/src/NewProject.res
+++ b/src/NewProject.res
@@ -37,6 +37,10 @@ let updateRescriptJson = async (~projectName, ~versions) =>
         config->Dict.set("suffix", String(suffix))
       | _ => ()
       }
+
+      if Option.isNone(versions.rescriptCoreVersion) {
+        RescriptJsonUtils.removeRescriptCore(config)
+      }
     | _ => ()
     }
   )

--- a/src/RescriptJsonUtils.res
+++ b/src/RescriptJsonUtils.res
@@ -1,0 +1,29 @@
+let removeRescriptCore = (config: Dict.t<JSON.t>) => {
+  // Remove @rescript/core from bs-dependencies if the version is not set.
+  switch config->Dict.get("bs-dependencies") {
+  | Some(Array(dependencies)) => {
+      let newDependencies = dependencies->Array.filter(dependency =>
+        switch dependency {
+        | String("@rescript/core") => false
+        | _ => true
+        }
+      )
+      config->Dict.set("bs-dependencies", Array(newDependencies))
+    }
+  | _ => ()
+  }
+
+  // Remove "-open RescriptCore" from bsc-flags if the version is not set.
+  switch config->Dict.get("bsc-flags") {
+  | Some(Array(flags)) => {
+      let newFlags = flags->Array.filter(flag =>
+        switch flag {
+        | String("-open RescriptCore") => false
+        | _ => true
+        }
+      )
+      config->Dict.set("bsc-flags", Array(newFlags))
+    }
+  | _ => ()
+  }
+}

--- a/src/RescriptVersions.res
+++ b/src/RescriptVersions.res
@@ -35,10 +35,18 @@ let promptVersions = async () => {
   let rescriptVersion = switch rescriptVersionsResult {
   | Ok([version]) => version
   | Ok(rescriptVersions) =>
-    await P.select({
-      message: "ReScript version?",
-      options: rescriptVersions->Array.map(v => {P.value: v}),
-    })->P.resultOrRaise
+    let options = rescriptVersions->Array.map(v => {P.value: v})
+
+    let initialValue =
+      options->Array.find(o => o.value->String.startsWith("11."))
+
+    let selectOptions = 
+      switch initialValue {
+        | None => { ClackPrompts.message: "ReScript version?", options}
+        | Some(initialValue) => {message: "ReScript version?", options, initialValue}
+      }
+
+    await P.select(selectOptions)->P.resultOrRaise
   | Error(error) => error->NpmRegistry.getFetchErrorMessage->Error.make->Error.raise
   }
 

--- a/src/RescriptVersions.res
+++ b/src/RescriptVersions.res
@@ -40,11 +40,7 @@ let promptVersions = async () => {
     let initialValue =
       options->Array.find(o => o.value->String.startsWith("11."))->Option.map(o => o.value)
 
-    let selectOptions = 
-      switch initialValue {
-        | None => { ClackPrompts.message: "ReScript version?", options}
-        | Some(initialValue) => {message: "ReScript version?", options, initialValue}
-      }
+    let selectOptions = {ClackPrompts.message: "ReScript version?", options, ?initialValue}
 
     await P.select(selectOptions)->P.resultOrRaise
   | Error(error) => error->NpmRegistry.getFetchErrorMessage->Error.make->Error.raise

--- a/src/RescriptVersions.res
+++ b/src/RescriptVersions.res
@@ -38,7 +38,7 @@ let promptVersions = async () => {
     let options = rescriptVersions->Array.map(v => {P.value: v})
 
     let initialValue =
-      options->Array.find(o => o.value->String.startsWith("11."))
+      options->Array.find(o => o.value->String.startsWith("11."))->Option.map(o => o.value)
 
     let selectOptions = 
       switch initialValue {

--- a/src/RescriptVersions.res
+++ b/src/RescriptVersions.res
@@ -1,6 +1,6 @@
 module P = ClackPrompts
 
-let rescript12VersionRange = "12.0.0-alpha.x"
+let rescript12VersionRange = ">=12.0.0-alpha.5"
 let rescriptVersionRange = `11.x.x || ${rescript12VersionRange}`
 let rescriptCoreVersionRange = ">=1.0.0"
 

--- a/src/RescriptVersions.resi
+++ b/src/RescriptVersions.resi
@@ -1,4 +1,4 @@
-type versions = {rescriptVersion: string, rescriptCoreVersion: string}
+type versions = {rescriptVersion: string, rescriptCoreVersion: option<string>}
 
 let promptVersions: unit => promise<versions>
 

--- a/src/bindings/ClackPrompts.res
+++ b/src/bindings/ClackPrompts.res
@@ -38,6 +38,7 @@ type selectOption = {
 type selectOptions = {
   message: string,
   options: array<selectOption>,
+  initialValue?: selectOption,
 }
 
 @module("@clack/prompts")

--- a/src/bindings/ClackPrompts.res
+++ b/src/bindings/ClackPrompts.res
@@ -38,7 +38,7 @@ type selectOption = {
 type selectOptions = {
   message: string,
   options: array<selectOption>,
-  initialValue?: selectOption,
+  initialValue?: string,
 }
 
 @module("@clack/prompts")

--- a/templates/rescript-template-basic/package.json
+++ b/templates/rescript-template-basic/package.json
@@ -11,8 +11,5 @@
   ],
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "@rescript/core": "^1.3.0",
-    "rescript": "^11.1.0"
-  }
+  "dependencies": {}
 }

--- a/templates/rescript-template-nextjs/package.json
+++ b/templates/rescript-template-nextjs/package.json
@@ -4,12 +4,10 @@
   "author": "Patrick Ecker <ryyppy@users.noreply.github.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@rescript/core": "^1.3.0",
     "@rescript/react": "^0.12.1",
     "next": "^14.0.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rescript": "^11.1.0"
+    "react-dom": "^18.2.0"
   },
   "repository": "https://github.com/rescript-lang/create-rescript-app",
   "scripts": {

--- a/templates/rescript-template-vite/package.json
+++ b/templates/rescript-template-vite/package.json
@@ -12,11 +12,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@rescript/core": "^1.3.0",
     "@rescript/react": "^0.12.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rescript": "^11.1.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",


### PR DESCRIPTION
- Allow selection of ReScript 12 alpha 5 and higher
- Skips selection of ReScript Core
- Updates rescript.json accordingly