### PR TITLE
feat: changed watch script in package.json when using rewatch

### DIFF
--- a/src/RescriptVersions.res
+++ b/src/RescriptVersions.res
@@ -3,6 +3,7 @@ module P = ClackPrompts
 let rescript12VersionRange = ">=12.0.0-alpha.5"
 let rescriptVersionRange = `11.x.x || ${rescript12VersionRange}`
 let rescriptCoreVersionRange = ">=1.0.0"
+let rescriptRewatchVersionRange = ">=12.0.0-alpha.15"
 
 type versions = {rescriptVersion: string, rescriptCoreVersion: option<string>}
 
@@ -95,3 +96,6 @@ let installVersions = async ({rescriptVersion, rescriptCoreVersion}) => {
 
 let esmModuleSystemName = ({rescriptVersion}) =>
   CompareVersions.compareVersions(rescriptVersion, "11.1.0-rc.8") > 0. ? "esmodule" : "es6"
+
+let usesRewatch = ({rescriptVersion}) =>
+  CompareVersions.satisfies(rescriptVersion, rescriptRewatchVersionRange)

--- a/src/RescriptVersions.resi
+++ b/src/RescriptVersions.resi
@@ -5,3 +5,5 @@ let promptVersions: unit => promise<versions>
 let installVersions: versions => promise<unit>
 
 let esmModuleSystemName: versions => string
+
+let usesRewatch: versions => bool


### PR DESCRIPTION
The new rescript version uses rewatch as build system.
Changed the `res:dev` script to be compatible with rewatch if using rescript >= `12.0.0-alpha.15`.