### PR TITLE
Update @rescript/react to v0.13.1 for ReScript v12 support

### DIFF
--- a/templates/rescript-template-nextjs/README.md
+++ b/templates/rescript-template-nextjs/README.md
@@ -9,8 +9,6 @@ This is a NextJS based template with following setup:
 - Some ReScript Bindings for Next to get you started
 - Preconfigured Dependencies: `@rescript/react`
 
-**Note:** This setup is based on the `v1` `package-lock` format utilized by `npm@6`. If you want to use the newer `v2` version, delete the `package-lock.json` file and install the dependencies with `npm@7`.
-
 ## Development
 
 Run ReScript in dev mode:

--- a/templates/rescript-template-nextjs/package-lock.json
+++ b/templates/rescript-template-nextjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@rescript/react": "^0.13.0",
+        "@rescript/react": "^0.13.1",
         "next": "^15.1.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@rescript/react": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.0.tgz",
-      "integrity": "sha512-YSIWIyMlyF9ZaP6Q3hScl1h3wRbdIP4+Cb7PlDt7Y1PG8M8VWYhLoIgLb78mbBHcwFbZu0d5zAt1LSX5ilOiWQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.1.tgz",
+      "integrity": "sha512-VIWtu/sAJyYmDVoAhit0LHDYQrW6RqZ6z8sh8san5cjEAT4klv8JWkiaSK3FGUfooUDkGUXXgKTkqyj8zRR21w==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -3004,9 +3004,9 @@
       }
     },
     "@rescript/react": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.0.tgz",
-      "integrity": "sha512-YSIWIyMlyF9ZaP6Q3hScl1h3wRbdIP4+Cb7PlDt7Y1PG8M8VWYhLoIgLb78mbBHcwFbZu0d5zAt1LSX5ilOiWQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.1.tgz",
+      "integrity": "sha512-VIWtu/sAJyYmDVoAhit0LHDYQrW6RqZ6z8sh8san5cjEAT4klv8JWkiaSK3FGUfooUDkGUXXgKTkqyj8zRR21w==",
       "requires": {}
     },
     "@swc/counter": {

--- a/templates/rescript-template-nextjs/package.json
+++ b/templates/rescript-template-nextjs/package.json
@@ -4,7 +4,7 @@
   "author": "Patrick Ecker <ryyppy@users.noreply.github.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@rescript/react": "^0.13.0",
+    "@rescript/react": "^0.13.1",
     "next": "^15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/templates/rescript-template-vite/package-lock.json
+++ b/templates/rescript-template-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rescript-template-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@rescript/react": "^0.13.0",
+        "@rescript/react": "^0.13.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@rescript/react": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.0.tgz",
-      "integrity": "sha512-YSIWIyMlyF9ZaP6Q3hScl1h3wRbdIP4+Cb7PlDt7Y1PG8M8VWYhLoIgLb78mbBHcwFbZu0d5zAt1LSX5ilOiWQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.1.tgz",
+      "integrity": "sha512-VIWtu/sAJyYmDVoAhit0LHDYQrW6RqZ6z8sh8san5cjEAT4klv8JWkiaSK3FGUfooUDkGUXXgKTkqyj8zRR21w==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.0.0",

--- a/templates/rescript-template-vite/package.json
+++ b/templates/rescript-template-vite/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@rescript/react": "^0.13.0",
+    "@rescript/react": "^0.13.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
ReScript v12 no longer has the pipe last (`|>`) operator, but `ReScriptReactRouter` from `@rescript/react` uses it in `v0.13.0`. This was fixed in [`v0.13.1`](https://github.com/rescript-lang/rescript-react/blob/master/CHANGELOG.md#0131).