### PR TITLE
Activate npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
 
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -109,7 +112,5 @@ jobs:
           name: ${{ needs.build.outputs.artifact_filename }}
 
       - name: Publish packages on npm with tag "next"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           npm publish ${{ needs.build.outputs.artifact_filename }} --tag next


### PR DESCRIPTION
token expired so I figured we should also switch to trusted publishing here as well